### PR TITLE
ARK-Identifier resolver 

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -15,6 +15,7 @@ import {EditlexComponent} from './components/editlex/editlex.component';
 import {EditnewsComponent} from './components/editnews/editnews.component';
 import {NewsItemsComponent} from './components/news-items/news-items.component';
 import {NewsitemViewerComponent} from './components/newsitem-viewer/newsitem-viewer.component';
+import {ArkResolveComponent} from './components/ark-resolve/ark-resolve.component';
 
 const routes: Routes = [{
   path: 'home',
@@ -28,6 +29,9 @@ const routes: Routes = [{
 }, {
   path: 'lemma/:iri',
   component: LemmaComponent
+}, {
+  path: 'ark/:iri',
+  component: ArkResolveComponent
 }, {
   path: 'lexica',
   component: LexicaComponent

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -56,6 +56,7 @@ import { NewsitemViewerComponent } from './components/newsitem-viewer/newsitem-v
 import { FlexLayoutModule } from '@angular/flex-layout';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
 import {MatProgressSpinnerModule} from "@angular/material/progress-spinner";
+import { ArkResolveComponent } from './components/ark-resolve/ark-resolve.component';
 
 export function initializeApp(appInitService: AppInitService) {
   return (): Promise<any> => {
@@ -87,6 +88,7 @@ export function initializeApp(appInitService: AppInitService) {
     EditnewsComponent,
     SafePipe,
     NewsitemViewerComponent,
+    ArkResolveComponent,
   ],
   entryComponents: [
     LoginComponent,

--- a/src/app/components/ark-resolve/ark-resolve.component.spec.ts
+++ b/src/app/components/ark-resolve/ark-resolve.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ArkResolveComponent } from './ark-resolve.component';
+
+describe('ArkResolveComponent', () => {
+  let component: ArkResolveComponent;
+  let fixture: ComponentFixture<ArkResolveComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ ArkResolveComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ArkResolveComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/components/ark-resolve/ark-resolve.component.ts
+++ b/src/app/components/ark-resolve/ark-resolve.component.ts
@@ -6,7 +6,7 @@ import {KnoraService} from "../../services/knora.service";
   selector: 'app-ark-resolve',
   template: `
     <p>
-      What is the requested thing with url {{objurl}}
+      You will be redirected to {{objurl}} shortly...
     </p>
   `,
   styles: [
@@ -32,7 +32,6 @@ export class ArkResolveComponent implements OnInit {
             this.router.navigate(['/article', this.objurl]);
           }
         }
-        console.log('==> Resource:', data);
       });
     });
   }

--- a/src/app/components/ark-resolve/ark-resolve.component.ts
+++ b/src/app/components/ark-resolve/ark-resolve.component.ts
@@ -1,0 +1,40 @@
+import { Component, OnInit } from '@angular/core';
+import {ActivatedRoute, Router} from "@angular/router";
+import {KnoraService} from "../../services/knora.service";
+
+@Component({
+  selector: 'app-ark-resolve',
+  template: `
+    <p>
+      What is the requested thing with url {{objurl}}
+    </p>
+  `,
+  styles: [
+  ]
+})
+export class ArkResolveComponent implements OnInit {
+  objurl: string;
+
+  constructor(public route: ActivatedRoute,
+              public knoraService: KnoraService,
+              private router: Router) {
+
+  }
+
+  ngOnInit(): void {
+    this.route.params.subscribe(params => {
+      this.objurl = params.iri;
+      this.knoraService.getResource(params.iri).subscribe((data) => {
+        for (const ele of data.properties) {
+          if (ele.propname === 'http://api.dasch.swiss/ontology/0807/mls/v2#hasLemmaText') {
+            this.router.navigate(['/lemma', this.objurl]);
+          } else {
+            this.router.navigate(['/article', this.objurl]);
+          }
+        }
+        console.log('==> Resource:', data);
+      });
+    });
+  }
+
+}


### PR DESCRIPTION
Special route for resolving ARK-ID's. The DaSCH ARK-resolver should redirect to https://mls.0807.dasch.swiss/ark/res_id.
This route the redirects either to lemma or article depending on what the resource represents